### PR TITLE
Fix prelude typing

### DIFF
--- a/src/Prelude.surf
+++ b/src/Prelude.surf
@@ -40,8 +40,8 @@ data Pair : Type -> Type -> Type where
 
 
 data Vec : Nat -> Type -> Type where
-  vnil : Vec zero a
-  vcons : a -> Vec n a -> Vec (succ n) a
+  vnil : (a : Type) -> Vec zero a
+  vcons : (n : Nat) -> (a : Type) -> a -> Vec n a -> Vec (succ n) a
 
 
 data Sigma : (A : Type) -> (B : A -> Type) -> Type where

--- a/src/Surface/Proof.hs
+++ b/src/Surface/Proof.hs
@@ -328,6 +328,10 @@ isType' ty = case unfix ty of
     isType ty
     D (name := Just ty) >- isType body
 
+  Sigma name ty body -> do
+    isType ty
+    T (name ::: ty) >- isType body
+
   Var name -> do
     def <- lookupDefinition name
     case def of

--- a/src/Surface/Proof.hs
+++ b/src/Surface/Proof.hs
@@ -357,12 +357,16 @@ alphaEquivalent' e1 e2
         alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
     (Pi n1 t1 b1, Pi n2 t2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
       alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
+    (Mu n1 t1 b1, Mu n2 t2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
+      alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
+    (Sigma n1 t1 b1, Sigma n2 t2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
+      alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
     (Let n1 v1 b1, Let n2 v2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2 `union` freeVariables v1 `union` freeVariables v2)) in
       alphaEquivalent (substitute new n1 v1) (substitute new n2 v2) >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
 
     (Var n1, Var n2) -> return (n1 == n2)
 
-    (a1, a2) -> case zipExprFWith (==) alphaEquivalent a1 a2 of -- FIXME: this should probably be testing under renaming.
+    (a1, a2) -> case zipExprFWith (==) alphaEquivalent a1 a2 of
       Just equivalences -> do
         eq <- sequenceA equivalences
         return (and eq)

--- a/src/Surface/Proof.hs
+++ b/src/Surface/Proof.hs
@@ -385,9 +385,9 @@ equate' :: HasCallStack => Expr -> Expr -> Proof ()
 equate' e1 e2 = do
   equivalent <- alphaEquivalent e1 e2
   unless equivalent $ do
-    nf1 <- whnf e1
-    nf2 <- whnf e2
-    case zipExprFWith (,) equate (unfix nf1) (unfix nf2) of
+    Fix nf1 <- whnf e1
+    Fix nf2 <- whnf e2
+    case zipExprFWith (,) equate nf1 nf2 of
       Just _ -> return ()
       _ -> fail ("Could not judge equality of " ++ prettyExpr 0 e1 (" to " ++ prettyExpr 0 e2 ""))
 

--- a/src/Surface/Proof.hs
+++ b/src/Surface/Proof.hs
@@ -152,7 +152,7 @@ runAll context proof = case runStep context proof of
 
 runSteps :: HasCallStack => Proof a -> ProofState -> [(Proof a, ProofState)]
 runSteps proof context = (proof, context) : case runStep proof context of
-  Left errors -> [ (Error errors `Then` return, context) ]
+  Left _ -> []
   Right r@(Return _, _) -> [ r ]
   Right next -> uncurry runSteps next
 

--- a/src/Surface/Proof.hs
+++ b/src/Surface/Proof.hs
@@ -355,14 +355,22 @@ alphaEquivalent' e1 e2
       | n1 == n2 -> alphaEquivalent b1 b2
       | otherwise -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
         alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
-    (Pi n1 t1 b1, Pi n2 t2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
-      alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
-    (Mu n1 t1 b1, Mu n2 t2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
-      alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
-    (Sigma n1 t1 b1, Sigma n2 t2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
-      alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
-    (Let n1 v1 b1, Let n2 v2 b2) -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2 `union` freeVariables v1 `union` freeVariables v2)) in
-      alphaEquivalent (substitute new n1 v1) (substitute new n2 v2) >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
+    (Pi n1 t1 b1, Pi n2 t2 b2)
+      | n1 == n2 -> alphaEquivalent t1 t2 >> alphaEquivalent b1 b2
+      | otherwise -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
+        alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
+    (Mu n1 t1 b1, Mu n2 t2 b2)
+      | n1 == n2 -> alphaEquivalent t1 t2 >> alphaEquivalent b1 b2
+      | otherwise -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
+        alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
+    (Sigma n1 t1 b1, Sigma n2 t2 b2)
+      | n1 == n2 -> alphaEquivalent t1 t2 >> alphaEquivalent b1 b2
+      | otherwise -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2)) in
+        alphaEquivalent t1 t2 >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
+    (Let n1 v1 b1, Let n2 v2 b2)
+      | n1 == n2 -> alphaEquivalent v1 v2 >> alphaEquivalent b1 b2
+      | otherwise -> let new = var (freshNameIn (n1 : n2 : freeVariables b1 `union` freeVariables b2 `union` freeVariables v1 `union` freeVariables v2)) in
+        alphaEquivalent (substitute new n1 v1) (substitute new n2 v2) >> alphaEquivalent (substitute new n1 b1) (substitute new n2 b2)
 
     (Var n1, Var n2) -> return (n1 == n2)
 


### PR DESCRIPTION
This PR fixes typechecking `vcons`. The `checkConstructor'` judgement naïvely insists that all free variables be of type `Type`, so we bind the variables instead.

`Sigma` still does not typecheck.