### PR TITLE
Fix data constructor typing

### DIFF
--- a/src/Prelude.surf
+++ b/src/Prelude.surf
@@ -40,8 +40,8 @@ data Pair : Type -> Type -> Type where
 
 
 data Vec : Nat -> Type -> Type where
-  vnil : (a : Type) -> Vec zero a
-  vcons : (n : Nat) -> (a : Type) -> a -> Vec n a -> Vec (succ n) a
+  vnil : Vec zero a
+  vcons : a -> Vec n a -> Vec (succ n) a
 
 
 data Sigma : (A : Type) -> (B : A -> Type) -> Type where

--- a/src/Surface/Command.hs
+++ b/src/Surface/Command.hs
@@ -13,19 +13,19 @@ data Command
 
 runCommand :: Command -> IO ()
 runCommand command = case command of
-    Interactive -> REPL.runREPL REPL.repl
-    Run path -> do
-      result <- parseFromFile source path
-      printResult $ do
-        modules <- result
-        for_ modules (runProof . checkModule)
-    Debug path -> do
-      result <- parseFromFile source path
-      traverse_ (traverse_ prettyPrint) $ do
-        modules <- result
-        return $ do
-          m <- toList modules
-          runSteps' (checkModule m :: Proof () ()) initialState
+  Interactive -> REPL.runREPL REPL.repl
+  Run path -> do
+    result <- parseFromFile source path
+    printResult $ do
+      modules <- result
+      for_ modules (runProof . checkModule)
+  Debug path -> do
+    result <- parseFromFile source path
+    traverse_ (traverse_ prettyPrint) $ do
+      modules <- result
+      return $ do
+        m <- toList modules
+        runSteps' (checkModule m :: Proof () ()) initialState
 
 printResult :: Pretty a => Either [String] a -> IO ()
 printResult result = case result of

--- a/src/Surface/Proof.hs
+++ b/src/Surface/Proof.hs
@@ -199,7 +199,7 @@ checkConstructor' _ decl (Constructor _ sig) = do
   modifyContext (:< Sep)
   env <- getEnvironment
   tyVariables <- traverse (fresh . Just) (domain (declarationType decl))
-  flip (foldr (>-)) (fmap (T . (::: typeT)) (freeVariables sig \\ H.keys env)) $ do
+  flip (foldr (>-)) (T . (::: typeT) <$> freeVariables sig \\ H.keys env) $ do
     isType sig
     equate (codomain sig) (foldl (#) (var (declarationName decl)) (fmap var tyVariables))
   _ <- skimContext []

--- a/src/Surface/Proof.hs
+++ b/src/Surface/Proof.hs
@@ -199,7 +199,9 @@ checkConstructor' _ decl (Constructor _ sig) = do
   modifyContext (:< Sep)
   env <- getEnvironment
   tyVariables <- traverse (fresh . Just) (domain (declarationType decl))
-  flip (foldr (>-)) (T . (::: typeT) <$> freeVariables sig \\ H.keys env) $ do
+  let sigVars = freeVariables sig \\ H.keys env
+  constructorT <- infer (foldr makeLambda sig sigVars)
+  flip (foldr (>-)) (zipWith ((T .) . (:::)) sigVars (domain constructorT)) $ do
     isType sig
     equate (codomain sig) (foldl (#) (var (declarationName decl)) (fmap var tyVariables))
   _ <- skimContext []


### PR DESCRIPTION
This PR fixes data constructor typing by no longer assuming that all free variables are type variables. Instead, we bind each free variable with a lambda and infer the lambda’s type, and use the domain list of the resulting function type as the types for the free variables when checking the signature.